### PR TITLE
Change macOS build target to 10.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,10 @@ jobs:
         run: |
           patch -p1 < ../patches/moltenvk-osxcross-compat.patch
 
+      - name: Change macOS build target to 10.13
+        run: |
+          patch -p1 < ../patches/moltenvk-1013-compat.patch
+
       - name: Fetch Dependencies (Use Built Cache)
         if: steps.cache-dependencies.outputs.cache-hit == 'true'
         run: |

--- a/patches/disable-absolute-paths-for-apple-compat.patch
+++ b/patches/disable-absolute-paths-for-apple-compat.patch
@@ -1,0 +1,33 @@
+diff --git a/glslang/Include/InfoSink.h b/glslang/Include/InfoSink.h
+index 23f495dc..137ede85 100644
+--- a/glslang/Include/InfoSink.h
++++ b/glslang/Include/InfoSink.h
+@@ -36,7 +36,7 @@
+ #define _INFOSINK_INCLUDED_
+ 
+ #include "../Include/Common.h"
+-#include <filesystem>
++//#include <filesystem>
+ #include <cmath>
+ 
+ namespace glslang {
+@@ -101,14 +101,14 @@ public:
+         snprintf(locText, maxSize, ":%d", loc.line);
+ 
+         if(loc.getFilename() == nullptr && shaderFileName != nullptr && absolute) {
+-            append(std::filesystem::absolute(shaderFileName).string());
++            //append(std::filesystem::absolute(shaderFileName).string());
+         } else {
+             std::string location = loc.getStringNameOrNum(false);
+-            if (absolute) {
+-                append(std::filesystem::absolute(location).string());
+-            } else {
++            //if (absolute) {
++            //    append(std::filesystem::absolute(location).string());
++            //} else {
+                 append(location);
+-            }
++            //}
+         }
+ 
+         append(locText);

--- a/patches/moltenvk-1013-compat.patch
+++ b/patches/moltenvk-1013-compat.patch
@@ -1,0 +1,56 @@
+diff --git a/ExternalDependencies.xcodeproj/project.pbxproj b/ExternalDependencies.xcodeproj/project.pbxproj
+index 27442c7b..be4c18d5 100644
+--- a/ExternalDependencies.xcodeproj/project.pbxproj
++++ b/ExternalDependencies.xcodeproj/project.pbxproj
+@@ -7176,7 +7176,7 @@
+ 				GCC_WARN_UNUSED_VARIABLE = NO;
+ 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+ 				MACH_O_TYPE = staticlib;
+-				MACOSX_DEPLOYMENT_TARGET = 10.15;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				SKIP_INSTALL = YES;
+ 				TVOS_DEPLOYMENT_TARGET = 13.0;
+ 			};
+@@ -7226,7 +7226,7 @@
+ 				GCC_WARN_UNUSED_VARIABLE = NO;
+ 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+ 				MACH_O_TYPE = staticlib;
+-				MACOSX_DEPLOYMENT_TARGET = 10.15;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				SKIP_INSTALL = YES;
+ 				TVOS_DEPLOYMENT_TARGET = 13.0;
+ 				VALIDATE_PRODUCT = YES;
+diff --git a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+index 7a029774..bd6ff644 100644
+--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
++++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+@@ -2692,7 +2692,7 @@
+ 					"\"${BUILT_PRODUCTS_DIR}\"",
+ 				);
+ 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+-				MACOSX_DEPLOYMENT_TARGET = 10.15;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				MARKETING_VERSION = "${CURRENT_PROJECT_VERSION}";
+ 				MTL_ENABLE_DEBUG_INFO = YES;
+ 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKShaderConverter.a";
+@@ -2765,7 +2765,7 @@
+ 					"\"${BUILT_PRODUCTS_DIR}\"",
+ 				);
+ 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+-				MACOSX_DEPLOYMENT_TARGET = 10.15;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				MARKETING_VERSION = "${CURRENT_PROJECT_VERSION}";
+ 				MTL_ENABLE_DEBUG_INFO = NO;
+ 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKShaderConverter.a";
+diff --git a/fetchDependencies b/fetchDependencies
+index a870c300..2a349868 100755
+--- a/fetchDependencies
++++ b/fetchDependencies
+@@ -369,6 +369,7 @@ else
+ 	./build_info.py .        \
+ 		-i build_info.h.tmpl  \
+ 		-o build/include/glslang/build_info.h
++	patch -p1 < ../../../patches/disable-absolute-paths-for-apple-compat.patch
+ 	cd -  > /dev/null
+ fi
+ 


### PR DESCRIPTION
Changes macOS build target to 10.13, MoltenVK supports 10.15+ only, but changing target should ensure missing symbols are loaded dynamically.

Should fix https://github.com/godotengine/godot/issues/94200 