### PR TITLE
Update MoltenVK to 1.2.11 (used in SDK 1.3.296 to 1.4.313)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,18 +16,17 @@ on:
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 jobs:
   build:
+    runs-on: macos-15
+
     strategy:
       matrix:
-        xcode: [ "15.0" ]
+        xcode: [ "16.4" ]
         platform: [ "all" ]
-        os: [ "macos-13" ]
         upload_artifacts: [ true ]
       fail-fast: false
 
     name: 'MoltenVK (Xcode ${{ matrix.xcode }} - ${{ matrix.platform }})'
-    
-    runs-on: ${{ matrix.os }}
-    
+
     env:
       XCODE_DEV_PATH: "/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer"
 
@@ -107,14 +106,14 @@ jobs:
         # To reduce artifact size, don't include any stand-alone shader converter binaries.
         run: |
           rm -rf Package/Release/MoltenVKShaderConverter
-          tar -C Package -s/Release/MoltenVK/ -cvf "MoltenVK-${{ matrix.platform }}.tar" Release/
+          tar -C Package -s/Release/MoltenVK/ -cvJf "MoltenVK-${{ matrix.platform }}.tar.xz" Release/
 
       - name: Upload Artifacts
         if: success() && matrix.upload_artifacts == true
         uses: actions/upload-artifact@v4
         with:
           name: "MoltenVK-${{ matrix.platform }}"
-          path: "MoltenVK/MoltenVK-${{ matrix.platform }}.tar"
+          path: "MoltenVK/MoltenVK-${{ matrix.platform }}.tar.xz"
 
   release:
     name: 'Release'


### PR DESCRIPTION
And some CI cleanup.

Latest Vulkan SDK is 1.4.313, so I'm planning to sync Godot with that one.

MoltenVK 1.3.0 was released shortly after that SDK version though, and I suppose it will be in the next SDK release.
I'll make a build of 1.3.0 after this so we can also test and see if it fixes some issues for us.